### PR TITLE
Change container demands

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 1.1.1 / 2022-06-10
+
+- Pipeline container demands parameterized
+
 ## 1.1.0 / 2022-04-29
 
 - Upgraded to .NET 6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EDS Analytics Sample and Test
 
-**Version:** 1.1.0
+**Version:** 1.1.1
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/Edge/aveva.sample-eds-eds_analytics-dotnet?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=2642&branchName=main)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ variables:
 
 parameters:
   - name: containerDemands
-    default: SKU -equals VSEnterprise2022
+    default: SKU -equals VSEnterprise
 
 jobs:
   - job: Tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
   - job: Tests
     pool:
       name: 00-OSIManaged-Build
-      demands: SKU -equals VSEnterprise2022
+      demands: $(containerDemands)
     steps:
       - task: UseDotNet@2
         displayName: 'Install dotnet 6'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,6 @@ resources:
       endpoint: osisoft/OSI-Samples
 
 variables:
-  - template: '/miscellaneous/build_templates/variables.yml@templates'
   - name: covStream
     value: SDSDotNetAPI
   - name: analysisProject

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,12 +34,15 @@ variables:
     value: SDSDotNetAPI
   - name: analysisProject
     value: EDS_Analytics_DotNet
+  - name: demands
+    value: $(containerDemands)
+
 
 jobs:
   - job: Tests
     pool:
       name: 00-OSIManaged-Build
-      demands: $(containerDemands)
+      demands: $(demands)
     steps:
       - task: UseDotNet@2
         displayName: 'Install dotnet 6'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
   - job: Tests
     pool:
       name: 00-OSIManaged-Build
-      demands: SKU -equals VSEnterprise
+      demands: SKU -equals VSEnterprise2022
     steps:
       - task: UseDotNet@2
         displayName: 'Install dotnet 6'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ variables:
   - name: analysisProject
     value: EDS_Analytics_DotNet
   - name: demands
-    value: $(containerDemands)
+    value: SKU -equals VSEnterprise2022
 
 
 jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,15 +33,15 @@ variables:
     value: SDSDotNetAPI
   - name: analysisProject
     value: EDS_Analytics_DotNet
-  - name: demands
-    value: SKU -equals VSEnterprise2022
 
+parameters:
+  containerDemands: SKU -equals VSEnterprise2022
 
 jobs:
   - job: Tests
     pool:
       name: 00-OSIManaged-Build
-      demands: $(demands)
+      demands: ${{ parameters.containerDemands }}
     steps:
       - task: UseDotNet@2
         displayName: 'Install dotnet 6'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,8 @@ variables:
     value: EDS_Analytics_DotNet
 
 parameters:
-  containerDemands: SKU -equals VSEnterprise2022
+  - name: containerDemands
+    default: SKU -equals VSEnterprise2022
 
 jobs:
   - job: Tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,7 @@ resources:
       endpoint: osisoft/OSI-Samples
 
 variables:
+  - template: '/miscellaneous/build_templates/variables.yml@templates'
   - name: covStream
     value: SDSDotNetAPI
   - name: analysisProject


### PR DESCRIPTION
Changed the pipeline container demands to be parameterized. This allows the default value to live in the pipeline's yml file, but the value can be overridden from the ADO pipeline page temporarily as needed to respond to temporary container pool maintenance and issues.